### PR TITLE
Update AFAudioRouter.m

### DIFF
--- a/Classes/AFAudioRouter.m
+++ b/Classes/AFAudioRouter.m
@@ -28,8 +28,8 @@
         UInt32 doSetProperty = 1;
         AudioSessionSetProperty (kAudioSessionProperty_OverrideCategoryMixWithOthers, sizeof(doSetProperty), &doSetProperty);
         
-        [[AVAudioSession sharedInstance]setDelegate:self];
-        [[AVAudioSession sharedInstance]setActive: YES error: nil];
+        [[AVAudioSession sharedInstance] setDelegate:(id\<AVAudioPlayerDelegate\>)self];
+        [[AVAudioSession sharedInstance] setActive: YES error: nil];
         
         AudioSessionAddPropertyListener (kAudioSessionProperty_AudioRouteChange, onAudioRouteChange, nil);
         AudioSessionAddPropertyListener (kAudioSessionProperty_AudioInputAvailable, onAudioRouteChange, nil);


### PR DESCRIPTION
Add (id<AVAudioPlayerDelegate>) in line 31:
[[AVAudioSession sharedInstance] setDelegate:(id<AVAudioPlayerDelegate>)self];

To get rid of warning:
Incompatible pointer types sending 'Class' to parameter of type 'id<AVAudioPlayerDelegate>'
