### PR TITLE
fixed finish logic for playing audio from stream

### DIFF
--- a/Classes/AFSoundManager.m
+++ b/Classes/AFSoundManager.m
@@ -89,7 +89,7 @@
         
         _timer = [NSTimer scheduledTimerWithTimeInterval:1 block:^{
             
-            if ((CMTimeGetSeconds(_player.currentItem.duration) - CMTimeGetSeconds(_player.currentItem.currentTime)) != 0) {
+            if ((CMTimeGetSeconds(_player.currentItem.duration) - CMTimeGetSeconds(_player.currentItem.currentTime)) > 1) {
                 
                 percentage = (int)((CMTimeGetSeconds(_player.currentItem.currentTime) * 100)/CMTimeGetSeconds(_player.currentItem.duration));
                 int timeRemaining = CMTimeGetSeconds(_player.currentItem.duration) - CMTimeGetSeconds(_player.currentItem.currentTime);


### PR DESCRIPTION
Cause when you compare floats you can't be sure of the exact coincidence of values
