### PR TITLE
Need AVAudioSessionCategory as a parameter

### DIFF
--- a/Classes/AFSoundPlayback.h
+++ b/Classes/AFSoundPlayback.h
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSInteger, AFSoundStatus) {
 };
 
 -(id)initWithItem:(AFSoundItem *)item;
--(id)initWithItem:(AFSoundItem *)item avAudioSessionCategory:(NSString *)categoryName
+-(id)initWithItem:(AFSoundItem *)item avAudioSessionCategory:(NSString *)categoryName;
 
 @property (nonatomic, strong) AVPlayer *player;
 @property (nonatomic) AFSoundStatus status;

--- a/Classes/AFSoundPlayback.h
+++ b/Classes/AFSoundPlayback.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSInteger, AFSoundStatus) {
 };
 
 -(id)initWithItem:(AFSoundItem *)item;
+-(id)initWithItem:(AFSoundItem *)item avAudioSessionCategory:(NSString *)categoryName
 
 @property (nonatomic, strong) AVPlayer *player;
 @property (nonatomic) AFSoundStatus status;

--- a/Classes/AFSoundPlayback.m
+++ b/Classes/AFSoundPlayback.m
@@ -39,6 +39,15 @@ NSString * const AFSoundPlaybackFinishedNotification = @"kAFSoundPlaybackFinishe
     return self;
 }
 
+-(id)initWithItem:(AFSoundItem *)item avAudioSessionCategory:(NSString *)categoryName {
+    if (self == [super init]) {
+        _currentItem = item;
+        [self setUpItem:item avAudioSessionCategory:categoryName];
+        _status = AFSoundStatusNotStarted;
+    }
+    return self;
+}
+
 -(void)setUpItem:(AFSoundItem *)item {
     
     _player = [[AVPlayer alloc] initWithURL:item.URL];
@@ -53,6 +62,12 @@ NSString * const AFSoundPlaybackFinishedNotification = @"kAFSoundPlaybackFinishe
     [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
     [[AVAudioSession sharedInstance] setActive:YES error:nil];
     [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
+}
+
+-(void)setUpItem:(AFSoundItem *)item avAudioSessionCategory:(NSString *)categoryName {
+    [self setUpItem:item];
+    [[AVAudioSession sharedInstance] setCategory:categoryName error:nil];
+    [[AVAudioSession sharedInstance] setActive:YES error:nil];
 }
 
 -(void)listenFeedbackUpdatesWithBlock:(feedbackBlock)block andFinishedBlock:(finishedBlock)finishedBlock {

--- a/Classes/AFSoundQueue.h
+++ b/Classes/AFSoundQueue.h
@@ -17,6 +17,7 @@ typedef void (^feedbackBlock)(AFSoundItem *item);
 typedef void (^itemFinishedBlock)(AFSoundItem *nextItem);
 
 -(id)initWithItems:(NSArray *)items;
+-(id)initWithItems:(NSArray *)items avAudioSessionCategory:(NSString *)categoryName;
 
 @property (nonatomic) AFSoundStatus status;
 

--- a/Classes/AFSoundQueue.m
+++ b/Classes/AFSoundQueue.m
@@ -184,9 +184,9 @@
         }
 
         if (_avAudioSessionCategoryName) {
-            _queuePlayer = [[AFSoundPlayback alloc] initWithItem:items.firstObject avAudioSessionCategory:_avAudioSessionCategoryName];
+            _queuePlayer = [[AFSoundPlayback alloc] initWithItem:item avAudioSessionCategory:_avAudioSessionCategoryName];
         } else {
-            _queuePlayer = [[AFSoundPlayback alloc] initWithItem:items.firstObject];
+            _queuePlayer = [[AFSoundPlayback alloc] initWithItem:item];
         }
         [_queuePlayer play];
         [[MPRemoteCommandCenter sharedCommandCenter] playCommand];

--- a/Classes/AFSoundQueue.m
+++ b/Classes/AFSoundQueue.m
@@ -18,6 +18,7 @@
 @property (nonatomic, strong) NSMutableArray *items;
 
 @property (nonatomic, strong) NSTimer *feedbackTimer;
+@property (nonatomic, copy)   NSString *avAudioSessionCategoryName;
 
 @end
 
@@ -31,13 +32,23 @@
             
             _items = [NSMutableArray arrayWithArray:items];
             
-            _queuePlayer = [[AFSoundPlayback alloc] initWithItem:items.firstObject];
+            if (_avAudioSessionCategoryName) {
+                _queuePlayer = [[AFSoundPlayback alloc] initWithItem:items.firstObject avAudioSessionCategory:_avAudioSessionCategoryName];
+            } else {
+                _queuePlayer = [[AFSoundPlayback alloc] initWithItem:items.firstObject];
+            }
             
             [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
         }
     }
     
     return self;
+}
+
+-(id)initWithItems:(NSArray *)items avAudioSessionCategory:(NSString *)categoryName {
+
+    _avAudioSessionCategoryName = categoryName;
+    return [self initWithItems:items];
 }
 
 -(void)listenFeedbackUpdatesWithBlock:(feedbackBlock)block andFinishedBlock:(itemFinishedBlock)finishedBlock {
@@ -172,7 +183,11 @@
 //            [_feedbackTimer resumeTimer];
         }
 
-        _queuePlayer = [[AFSoundPlayback alloc] initWithItem:item];
+        if (_avAudioSessionCategoryName) {
+            _queuePlayer = [[AFSoundPlayback alloc] initWithItem:items.firstObject avAudioSessionCategory:_avAudioSessionCategoryName];
+        } else {
+            _queuePlayer = [[AFSoundPlayback alloc] initWithItem:items.firstObject];
+        }
         [_queuePlayer play];
         [[MPRemoteCommandCenter sharedCommandCenter] playCommand];
         


### PR DESCRIPTION
When I call `-(void)playItemAtIndex:(NSInteger)index` in `AFSoundQueue` class, the sound will be played in spite of silent mode.
